### PR TITLE
VO 수정, 결과 보여주는 방법 수정

### DIFF
--- a/Rodin/src/main/java/rodin/controller/AnalysisController.java
+++ b/Rodin/src/main/java/rodin/controller/AnalysisController.java
@@ -218,6 +218,7 @@ public class AnalysisController {
 		
 		fvo.setAccuracy(fontAccuracy);
 		fvo.setFontPiece(fontFullName);
+		fvo.setOcr(ocr);
 		logger.debug("FontVo : " + fvo.toString());
 		
 		session.setAttribute("accu_1st", fvo);

--- a/Rodin/src/main/java/rodin/repository/vo/FontVo.java
+++ b/Rodin/src/main/java/rodin/repository/vo/FontVo.java
@@ -18,7 +18,14 @@ public class FontVo {
 	// Custom Font Information
 	private double accuracy;
 	private String fontPiece;
+	private String ocr;
 	
+	public String getOcr() {
+		return ocr;
+	}
+	public void setOcr(String ocr) {
+		this.ocr = ocr;
+	}
 	public double getAccuracy() {
 		return accuracy;
 	}
@@ -103,7 +110,7 @@ public class FontVo {
 				+ ", fontsLicense1=" + fontsLicense1 + ", fontsLicense2=" + fontsLicense2 + ", fontsLicense3="
 				+ fontsLicense3 + ", fontsLicense4=" + fontsLicense4 + ", fontsLicense5=" + fontsLicense5
 				+ ", fontsLicense6=" + fontsLicense6 + ", fontsLicense7=" + fontsLicense7 + ", regdate=" + regdate
-				+ ", accuracy=" + accuracy + ", fontPiece=" + fontPiece + "]";
+				+ ", accuracy=" + accuracy + ", fontPiece=" + fontPiece + ", ocr=" + ocr + "]";
 	}
 
 }

--- a/Rodin/src/main/java/rodin/repository/vo/FontVo.java
+++ b/Rodin/src/main/java/rodin/repository/vo/FontVo.java
@@ -15,6 +15,22 @@ public class FontVo {
 	private String fontsLicense7;	// 재배포
 	private Date regdate;
 	
+	// Custom Font Information
+	private double accuracy;
+	private String fontPiece;
+	
+	public double getAccuracy() {
+		return accuracy;
+	}
+	public void setAccuracy(double accuracy) {
+		this.accuracy = accuracy;
+	}
+	public String getFontPiece() {
+		return fontPiece;
+	}
+	public void setFontPiece(String fontPiece) {
+		this.fontPiece = fontPiece;
+	}
 	public Long getFontsno() {
 		return fontsno;
 	}
@@ -87,6 +103,7 @@ public class FontVo {
 				+ ", fontsLicense1=" + fontsLicense1 + ", fontsLicense2=" + fontsLicense2 + ", fontsLicense3="
 				+ fontsLicense3 + ", fontsLicense4=" + fontsLicense4 + ", fontsLicense5=" + fontsLicense5
 				+ ", fontsLicense6=" + fontsLicense6 + ", fontsLicense7=" + fontsLicense7 + ", regdate=" + regdate
-				+ "]";
+				+ ", accuracy=" + accuracy + ", fontPiece=" + fontPiece + "]";
 	}
+
 }

--- a/Rodin/src/main/webapp/WEB-INF/views/analysis/analysis.jsp
+++ b/Rodin/src/main/webapp/WEB-INF/views/analysis/analysis.jsp
@@ -77,7 +77,7 @@
 					</div>
 					<div class="modal-body cropped-image">
 						<div class="result-container">
-							<img id="cropped-image" src="" >
+							
 							<!-- 
 							<p>폰트이름 : ${accu_1st.fontsName }</p>
 							<p>제작회사 : ${accu_1st.fontsCompany }</p>
@@ -181,7 +181,7 @@
 		}
 		
 		document.getElementById('to-cropper').addEventListener('click', function() {
-			$croppedImageBox.css('display', 'none');
+			// $croppedImageBox.css('display', 'none');
 			$alert.hide();
 			$modal.modal('show');	
 		});
@@ -197,18 +197,18 @@
 		});
 		
 		document.getElementById('crop').addEventListener('click', function() {
-			//var initialURL;
-			
-			
+			// var initialURL;
+
 			// $modal.modal('hide');
 			var canvas = cropper.getCroppedCanvas({
 				maxWidth: 500,
 				maxHeight: 500,
 			});
-			$croppedImageBox.css('display', 'block');
-			croppedImage.src = canvas.toDataURL();
+			// $croppedImageBox.css('display', 'block');
+			// croppedImage.src = canvas.toDataURL();
 			$alert.removeClass('alert-success alert-warning');
 			//initialURL = image.src;
+		
 			canvas.toBlob(function (blob){
 				var formData = new FormData();
 				
@@ -221,6 +221,7 @@
 					processData: false,
 					contentType: false,
 					success: function() {
+						// $croppedImageBox.css('display', 'block');
 						// $alert.show().addClass('alert-success').text('Upload success');
 						// alert(result);
 						/*
@@ -234,9 +235,11 @@
 								// alert("data : ", data.fontsName);
 								
 								// alert(data.font.fontsName);
+								$(".result-container").children().remove();
 								$(
+									'<img id="cropped-image" src="' + canvas.toDataURL() + '" >' +
 									'<div class="img-container">' +
-										'<img src="https://rodin-image.s3.ap-northeast-2.amazonaws.com/abc/' + data.font.fontPiece + '">' +
+										'<img src="https://rodin-font-image.s3.ap-northeast-2.amazonaws.com/abc/' + data.font.ocr + '/' + data.font.fontPiece + '">' +
 									'</div>' + 
 									'<p>폰트이름 : ' + data.font.fontsName + '</p>' + 
 									'<p>제작회사 : ' + data.font.fontsCompany + '</p>'  + 

--- a/Rodin/src/main/webapp/WEB-INF/views/analysis/analysis.jsp
+++ b/Rodin/src/main/webapp/WEB-INF/views/analysis/analysis.jsp
@@ -1,5 +1,7 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
 <!DOCTYPE HTML>
 <html>
 	<head>
@@ -74,11 +76,22 @@
 						</div>
 					</div>
 					<div class="modal-body cropped-image">
-						<div>
+						<div class="result-container">
 							<img id="cropped-image" src="" >
+							<!-- 
 							<p>폰트이름 : ${accu_1st.fontsName }</p>
 							<p>제작회사 : ${accu_1st.fontsCompany }</p>
 							<p>재배포 가능 여부 : ${accu_1st.fontsLicense7 }</p>
+							<p>정확도 : <fmt:formatNumber value="${accu_1st.accuracy }" pattern=".00"/>%</p>
+							<p>등록날짜 : ${accu_1st.regdate }</p>
+							-->
+							<!-- 
+							<p>폰트이름 : ${font.fontsName }</p>
+							<p>제작회사 : ${font.fontsCompany }</p>
+							<p>재배포 가능 여부 : ${font.fontsLicense7 }</p>
+							<p>정확도 : <fmt:formatNumber value="${font.accuracy }" pattern=".00"/>%</p>
+							<p>등록날짜 : ${font.regdate }</p>
+							 -->
 						</div>
 					</div>
 					<div class="modal-footer">
@@ -209,6 +222,33 @@
 					contentType: false,
 					success: function() {
 						// $alert.show().addClass('alert-success').text('Upload success');
+						// alert(result);
+						/*
+						
+						*/
+						$.ajax({
+							url: '<c:url value="/analysis/getFontInfo" />',
+							method: 'POST',
+							dataType: "json",
+							success: function(data) {
+								// alert("data : ", data.fontsName);
+								
+								// alert(data.font.fontsName);
+								$(
+									'<div class="img-container">' +
+										'<img src="https://rodin-image.s3.ap-northeast-2.amazonaws.com/abc/' + data.font.fontPiece + '">' +
+									'</div>' + 
+									'<p>폰트이름 : ' + data.font.fontsName + '</p>' + 
+									'<p>제작회사 : ' + data.font.fontsCompany + '</p>'  + 
+									'<p>재배포 가능 여부 : ' + data.font.fontsLicense7 + '</p>' +  
+									'<p>정확도 : ' + data.font.accuracy.toFixed(2) + '%</p>'
+								).appendTo($(".result-container"));
+							},
+							error: function() {
+								alert("failed");
+							}
+						});
+
 					},
 					error: function() {
 						croppedImage.src = baseSrc;
@@ -220,7 +260,7 @@
 				});
 				//alert(formData);
 			});
-			
+
 			
 		});
 		


### PR DESCRIPTION
# 수정내용
## VO
### Property 추가
1. `accuracy` : VO 객체에 담아서 한번에 이동이 가능하도록 하기 위함
2. `fontPiece` : 비교대상이 되는 폰트 이미지 이름 알아내는 용도
3. `ocr` : `fontPiece`를 불러오기 위해 Amazon S3의 Bucket에 저장된 Key값을 알아내는 용도(경로)
## View
### 기존 방법
- `Model`이나 `Session`에 객체를 Set 하여 `View`에서 EL/JSTL을 이용하여 사용함
### 변경하는 이유
- `ajax`를 이용하여 실시간(새로고침 없이) 정보 변경되도록 할 경우 `Model`/`Session`에 등록된 값은 현 시점에서 `Null`이며 새로고침(?)이 한번 되어야 `Mode`l/`Session` 내용이 등록되어 `ajax`의 의미가 없어짐
### 변경 내용
- 기존 코드는 삭제하지는 않았음
- View에서 Response로 결과가 저장된 FontVO를 전달받은 후 JSON 형태로 변환되어 넘어오면 필요한 정보를 JSON 객체에서 바로 꺼내어 사용 
